### PR TITLE
Modify branch display to only show the current branch

### DIFF
--- a/SGColourPrompt/SGColourPrompt.psd1
+++ b/SGColourPrompt/SGColourPrompt.psd1
@@ -12,7 +12,7 @@
     RootModule = 'SGColourPrompt.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.2'
+    ModuleVersion     = '2.2.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/SGColourPrompt/SGColourPrompt.psm1
+++ b/SGColourPrompt/SGColourPrompt.psm1
@@ -48,7 +48,9 @@ function use-colour {
     
     # Use the branch name in the prompt or "..." if the branch
     # cannot be determined (possible if no commits have been made):
-    $branch_name = ((git branch) -replace '\* ', '')  # Remove the leading "* "
+    # Remove the need to replace the * by showing only the current branch.
+    # Reference: https://stackoverflow.com/a/6245587
+    $branch_name = (git branch --show-current)
     $branch_name = if ($null -eq $branch_name) { "..." } else { $branch_name }
     
     # Check if there are any tracked or untracked changes:


### PR DESCRIPTION
This seems to fix the issue of multiple branches showing up in the terminal.